### PR TITLE
#7 초기페이지 뉴스피드 미출력관련 오류

### DIFF
--- a/src/core/route.ts
+++ b/src/core/route.ts
@@ -3,10 +3,12 @@ import View from './view';
 
 export default class Router {
     routeTable:RouteInfo[]
-    defaultRoute: RouteInfo | null
+    defaultRoute: RouteInfo | null;
+
     constructor(){
         
-      this.routeTable = [];    
+      this.routeTable = [];
+      this.defaultRoute = null;
       window.addEventListener('hashchange', this.route.bind(this));
     }
   
@@ -21,7 +23,7 @@ export default class Router {
     route(){
       const routePath = location.hash;
       
-      if (routePath === '') {
+      if (routePath === '' && this.defaultRoute) {
         this.defaultRoute.page.render();
       } 
       


### PR DESCRIPTION
라우터에서 초기 페이지에 대한 초기화가 되는 점, 초기 페이지 출력시, 해당 초기 페이지 변수가 null체크가 빠진 점을 수정

정상적으로 초기 페이지 출력되었음을 확인함